### PR TITLE
test(extension): harden search URL matching

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,4 +16,9 @@ jobs:
         run: python3 -c "import json; json.load(open('manifest.json'))"
 
       - name: Check JS syntax
-        run: node --check background.js
+        run: |
+          node --check background.mjs
+          node --check searchMatcher.mjs
+
+      - name: Run matcher regression tests
+        run: node search-matcher.test.mjs

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A Chrome extension that closes all search engine tabs with one click (or `Ctrl+S
 ## Features
 
 - **One-click cleanup** — click the icon or press `Ctrl+Shift+Z` to close all search tabs
+- **Smarter URL matching** — uses parsed URLs instead of loose substring checks, which reduces false positives and picks up localized Google domains like `google.co.uk`
 - **Badge counter** — shows the number of open search tabs on the extension icon
 - **Lightweight** — no permissions beyond `tabs`, no background overhead
 

--- a/background.mjs
+++ b/background.mjs
@@ -1,27 +1,4 @@
-const SEARCH_PATTERNS = [
-  "google.com/search?",
-  "google.com/search#",
-  "duckduckgo.com/?q=",
-  "duckduckgo.com/?t=",
-  "bing.com/search?",
-  "search.yahoo.com/search",
-  "search.brave.com/search?",
-  "ecosia.org/search?",
-  "startpage.com/search",
-  "kagi.com/search?",
-  "yandex.com/search/?",
-  "perplexity.ai/search",
-  "you.com/search?",
-  "swisscows.com/web?",
-  "search.aol.com/search",
-  "baidu.com/s?",
-  "qwant.com/?q=",
-];
-
-function isSearchTab(tab) {
-  if (!tab.url) return false;
-  return SEARCH_PATTERNS.some((pattern) => tab.url.includes(pattern));
-}
+import { isSearchTab } from "./searchMatcher.mjs";
 
 function updateBadge() {
   chrome.tabs.query({}, (tabs) => {
@@ -39,7 +16,6 @@ chrome.action.onClicked.addListener(() => {
   });
 });
 
-// Update badge when tabs change
 chrome.tabs.onUpdated.addListener((_tabId, changeInfo) => {
   if (changeInfo.url || changeInfo.status === "complete") {
     updateBadge();
@@ -54,5 +30,4 @@ chrome.tabs.onCreated.addListener(() => {
   updateBadge();
 });
 
-// Initial badge update
 updateBadge();

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,8 @@
     "default_icon": "static/icon.png"
   },
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.mjs",
+    "type": "module"
   },
   "permissions": [
     "tabs"

--- a/search-matcher.test.mjs
+++ b/search-matcher.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { isSearchURL } from "./searchMatcher.mjs";
+
+const positives = [
+  "https://www.google.com/search?q=openclaw",
+  "https://www.google.co.uk/search?q=clawd",
+  "https://duckduckgo.com/?q=ai+assistant",
+  "https://www.bing.com/search?q=signal",
+  "https://search.yahoo.com/search?p=wallace",
+  "https://search.brave.com/search?q=repo",
+  "https://www.ecosia.org/search?q=trees",
+  "https://www.startpage.com/search?query=privacy",
+  "https://kagi.com/search?q=go",
+  "https://yandex.com/search/?text=browser",
+  "https://www.perplexity.ai/search?q=test",
+  "https://you.com/search?q=weather",
+  "https://swisscows.com/web?query=code",
+  "https://search.aol.com/search?q=music",
+  "https://www.baidu.com/s?wd=golang",
+  "https://www.qwant.com/?q=security",
+];
+
+const negatives = [
+  "https://www.google.com/",
+  "https://news.google.com/search?q=openclaw",
+  "https://duckduckgo.com/?t=h_&ia=web",
+  "https://search.yahoo.com/",
+  "https://example.com/?redirect=google.com/search?q=nope",
+  "not a url",
+  "",
+  null,
+];
+
+for (const url of positives) {
+  assert.equal(isSearchURL(url), true, `${url} should match`);
+}
+
+for (const url of negatives) {
+  assert.equal(isSearchURL(url), false, `${url} should not match`);
+}
+
+console.log(`validated ${positives.length} positive and ${negatives.length} negative search URL cases`);

--- a/searchMatcher.mjs
+++ b/searchMatcher.mjs
@@ -1,0 +1,48 @@
+const hasParam = (url, name) => url.searchParams.has(name) && url.searchParams.get(name) !== "";
+
+const endsWithAny = (value, suffixes) => suffixes.some((suffix) => value === suffix || value.endsWith(`.${suffix}`));
+
+const isGoogleSearchHost = (hostname) => {
+  if (hostname === "google.com" || hostname === "www.google.com") return true;
+
+  const googleParts = hostname.split(".");
+  if (googleParts.length < 2) return false;
+
+  const [subdomain, domain] = googleParts;
+  return subdomain === "www" && domain === "google";
+};
+
+const SEARCH_MATCHERS = [
+  (url) => isGoogleSearchHost(url.hostname) && url.pathname === "/search" && hasParam(url, "q"),
+  (url) => url.hostname === "duckduckgo.com" && url.pathname === "/" && hasParam(url, "q"),
+  (url) => endsWithAny(url.hostname, ["bing.com"]) && url.pathname === "/search" && hasParam(url, "q"),
+  (url) => url.hostname === "search.yahoo.com" && url.pathname === "/search" && hasParam(url, "p"),
+  (url) => url.hostname === "search.brave.com" && url.pathname === "/search" && hasParam(url, "q"),
+  (url) => endsWithAny(url.hostname, ["ecosia.org"]) && url.pathname === "/search" && hasParam(url, "q"),
+  (url) => endsWithAny(url.hostname, ["startpage.com"]) && url.pathname.includes("search") && hasParam(url, "query"),
+  (url) => url.hostname === "kagi.com" && url.pathname === "/search" && hasParam(url, "q"),
+  (url) => endsWithAny(url.hostname, ["yandex.com"]) && url.pathname.startsWith("/search") && hasParam(url, "text"),
+  (url) => endsWithAny(url.hostname, ["perplexity.ai"]) && url.pathname.startsWith("/search"),
+  (url) => url.hostname === "you.com" && url.pathname === "/search" && hasParam(url, "q"),
+  (url) => endsWithAny(url.hostname, ["swisscows.com"]) && url.pathname === "/web" && hasParam(url, "query"),
+  (url) => url.hostname === "search.aol.com" && url.pathname.includes("/search") && hasParam(url, "q"),
+  (url) => endsWithAny(url.hostname, ["baidu.com"]) && url.pathname === "/s" && hasParam(url, "wd"),
+  (url) => endsWithAny(url.hostname, ["qwant.com"]) && url.pathname === "/" && hasParam(url, "q"),
+];
+
+export function isSearchURL(rawURL) {
+  if (!rawURL) return false;
+
+  let parsedURL;
+  try {
+    parsedURL = new URL(rawURL);
+  } catch {
+    return false;
+  }
+
+  return SEARCH_MATCHERS.some((matcher) => matcher(parsedURL));
+}
+
+export function isSearchTab(tab) {
+  return Boolean(tab?.url) && isSearchURL(tab.url);
+}


### PR DESCRIPTION
## Summary
- replace brittle substring-based detection with URL-parsed matchers for each supported engine
- move the background worker to an ES module and share the matcher logic with a Node regression test
- extend CI to validate both module syntax and the matcher test cases

## Validation
- python3 -c "import json; json.load(open("manifest.json"))"
- node --check background.mjs
- node --check searchMatcher.mjs
- node search-matcher.test.mjs