### PR TITLE
fix: match Google country domains without www

### DIFF
--- a/search-matcher.test.mjs
+++ b/search-matcher.test.mjs
@@ -3,7 +3,9 @@ import { isSearchURL } from "./searchMatcher.mjs";
 
 const positives = [
   "https://www.google.com/search?q=openclaw",
+  "https://google.co.uk/search?q=clawd",
   "https://www.google.co.uk/search?q=clawd",
+  "https://google.com.au/search?q=widget",
   "https://duckduckgo.com/?q=ai+assistant",
   "https://www.bing.com/search?q=signal",
   "https://search.yahoo.com/search?p=wallace",
@@ -22,6 +24,7 @@ const positives = [
 
 const negatives = [
   "https://www.google.com/",
+  "https://googleusercontent.com/search?q=openclaw",
   "https://news.google.com/search?q=openclaw",
   "https://duckduckgo.com/?t=h_&ia=web",
   "https://search.yahoo.com/",

--- a/searchMatcher.mjs
+++ b/searchMatcher.mjs
@@ -3,13 +3,14 @@ const hasParam = (url, name) => url.searchParams.has(name) && url.searchParams.g
 const endsWithAny = (value, suffixes) => suffixes.some((suffix) => value === suffix || value.endsWith(`.${suffix}`));
 
 const isGoogleSearchHost = (hostname) => {
-  if (hostname === "google.com" || hostname === "www.google.com") return true;
+  const normalizedHostname = hostname.toLowerCase();
+  if (normalizedHostname === "google.com" || normalizedHostname === "www.google.com") return true;
 
-  const googleParts = hostname.split(".");
-  if (googleParts.length < 2) return false;
+  const googleHostname = normalizedHostname.startsWith("www.")
+    ? normalizedHostname.slice(4)
+    : normalizedHostname;
 
-  const [subdomain, domain] = googleParts;
-  return subdomain === "www" && domain === "google";
+  return googleHostname.startsWith("google.") && googleHostname.length > "google.".length;
 };
 
 const SEARCH_MATCHERS = [


### PR DESCRIPTION
## Summary
- accept Google search hosts that use country domains without a leading www
- keep the matcher scoped to real google.* hosts instead of unrelated lookalikes
- add regression tests for naked Google country domains and a negative googleusercontent.com case

## Testing
- node --test search-matcher.test.mjs